### PR TITLE
Serverless Website Component: Added CloudFront Feture

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ myWebsite:
     region: us-east-1 # The AWS region to deploy your website into
     bucketName: myBucket # (Optional) The Bucket name where `src` files/folder will be upload. 
                          # If not provided, it will create random bucket name and upload `src` files
+    cloudFront: # (Optional)
+        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distrubution to complete
+        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distrubution to complete
+        customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
     env: # Environment variables to include in a 'env.js' file with your uploaded code.
       API_URL: https://api.com
       

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ myWebsite:
     bucketName: myBucket # (Optional) The Bucket name where `src` files/folder will be upload. 
                          # If not provided, it will create random bucket name and upload `src` files
     cloudFront: # (Optional)
-        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distrubution to complete
-        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distrubution to complete
+        waitForCreateDistribution: true  # (Optional) wait for create cloudfront distribution to complete
+        waitForUpdateDistribution: false # (Optional) wait for update cloudfront distribution to complete
         customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
     env: # Environment variables to include in a 'env.js' file with your uploaded code.
       API_URL: https://api.com

--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ $ serverless
 ### New to Components?
 
 Checkout the [Serverless Components](https://github.com/serverless/components) repo for more information.
+
+&nbsp;
+
+### Publishing new versions
+New versions of this fork should be published from the `master` branch
+using `npm publish`. Remember to bump the package version as appropriate before publishing.

--- a/awsRegionUrls.json
+++ b/awsRegionUrls.json
@@ -1,0 +1,22 @@
+{
+  "us-east-2": "s3-website.us-east-2.amazonaws.com",
+  "us-east-1": "s3-website-us-east-1.amazonaws.com",
+  "us-west-1": "s3-website-us-west-1.amazonaws.com",
+  "us-west-2": "s3-website-us-west-2.amazonaws.com",
+  "ap-east-1": "s3-website.ap-east-1.amazonaws.com",
+  "ap-south-1": "s3-website.ap-south-1.amazonaws.com",
+  "ap-northeast-3": "s3-website.ap-northeast-3.amazonaws.com",
+  "ap-northeast-2": "s3-website.ap-northeast-2.amazonaws.com",
+  "ap-southeast-1": "s3-website-ap-southeast-1.amazonaws.com",
+  "ap-southeast-2": "s3-website-ap-southeast-2.amazonaws.com",
+  "ap-northeast-1": "s3-website-ap-northeast-1.amazonaws.com",
+  "ca-central-1": "s3-website.ca-central-1.amazonaws.com",
+  "cn-northwest-1": "s3-website.cn-northwest-1.amazonaws.com.cn",
+  "eu-central-1": "s3-website.eu-central-1.amazonaws.com",
+  "eu-west-1": "s3-website-eu-west-1.amazonaws.com",
+  "eu-west-2": "s3-website.eu-west-2.amazonaws.com",
+  "eu-west-3": "s3-website.eu-west-3.amazonaws.com",
+  "eu-north-1": "s3-website.eu-north-1.amazonaws.com",
+  "sa-east-1": "s3-website-sa-east-1.amazonaws.com",
+  "me-south-1": "s3-website.me-south-1.amazonaws.com"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -15,7 +15,7 @@
     "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",
     "@ublend-npm/serverless-compoonent-domain": "^0.0.8",
-    "aws-sdk": "2.1259.0"
+    "aws-sdk": "^2.1259.0"
   },
   "devDependencies": {
     "babel-eslint": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.16",
+  "version": "0.0.18",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@serverless/website",
-  "version": "3.0.9",
+  "name": "@ublend-npm/serverless-website-component",
+  "version": "0.0.12",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -15,7 +15,7 @@
     "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",
     "@serverless/domain": "^2.0.0",
-    "aws-sdk": "^2.499.0"
+    "aws-sdk": "2.1259.0"
   },
   "devDependencies": {
     "babel-eslint": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.12",
+  "version": "0.0.15",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -14,7 +14,7 @@
   "dependencies": {
     "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",
-    "@serverless/domain": "^2.0.0",
+    "@ublend-npm/serverless-compoonent-domain": "^0.0.8",
     "aws-sdk": "2.1259.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@serverless/website",
-  "version": "3.0.9",
+  "name": "@ublend-npm/serverless-website-component",
+  "version": "0.0.1",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -10,7 +10,7 @@
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
-  "license": "Apache",
+  "license": "UNLICENSED",
   "dependencies": {
     "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/website",
-  "version": "3.0.2",
+  "version": "3.0.9",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -12,9 +12,9 @@
   "author": "Serverless, Inc.",
   "license": "Apache",
   "dependencies": {
-    "@serverless/aws-s3": "^2.0.7",
+    "@serverless/aws-s3": "^2.0.0",
     "@serverless/core": "^1.0.0",
-    "@serverless/domain": "^2.0.6",
+    "@serverless/domain": "^2.0.0",
     "aws-sdk": "^2.499.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ublend-npm/serverless-website-component",
-  "version": "0.0.1",
+  "name": "@serverless/website",
+  "version": "3.0.2",
   "main": "./serverless.js",
   "publishConfig": {
     "access": "public"
@@ -10,11 +10,11 @@
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
-  "license": "UNLICENSED",
+  "license": "Apache",
   "dependencies": {
-    "@serverless/aws-s3": "^2.0.0",
+    "@serverless/aws-s3": "^2.0.7",
     "@serverless/core": "^1.0.0",
-    "@serverless/domain": "^2.0.0",
+    "@serverless/domain": "^2.0.6",
     "aws-sdk": "^2.499.0"
   },
   "devDependencies": {

--- a/serverless.js
+++ b/serverless.js
@@ -130,7 +130,7 @@ class Website extends Component {
           ...cloudFront,
           customLambdaAssociations: [
             {
-              functionName: `${institution}-security-headers-injector-prod-injectSecurityHeaders`,
+              functionName: `${institution}-security-headers-injector-prod-injectHeaders`,
               type: 'origin-response'
             }
           ]

--- a/serverless.js
+++ b/serverless.js
@@ -20,7 +20,9 @@ class Website extends Component {
    * Types
    */
 
-  types() { return types }
+  types() {
+    return types
+  }
 
   /*
    * Default
@@ -119,7 +121,11 @@ class Website extends Component {
         subdomains: {}
       }
 
-      domainInputs.subdomains[subdomain] = { url: this.state.url }
+      domainInputs.subdomains[subdomain] = {
+        url: this.state.url,
+        bucketName: this.state.bucketName,
+        cloudFront: inputs.cloudFront
+      }
       const domainOutputs = await domain(domainInputs)
 
       outputs.domain = domainOutputs.domains[0]

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,13 @@
 const { utils } = require('@serverless/core')
 
 const configureBucketForHosting = async (s3, bucketName) => {
+  const publicAccessBlockConfig = {
+    BlockPublicAcls: false,
+    BlockPublicPolicy: false,
+    IgnorePublicAcls: false,
+    RestrictPublicBuckets: false
+  }
+
   const s3BucketPolicy = {
     Version: '2012-10-17',
     Statement: [
@@ -41,6 +48,13 @@ const configureBucketForHosting = async (s3, bucketName) => {
   }
 
   try {
+    await s3
+      .putPublicAccessBlock({
+        Bucket: bucketName,
+        PublicAccessBlockConfiguration: publicAccessBlockConfig
+      })
+      .promise()
+
     await s3
       .putBucketPolicy({
         Bucket: bucketName,


### PR DESCRIPTION
This PR is the continuation of other PR at `serverless/domain` https://github.com/serverless-components/domain/pull/6

This changeset passes s3 bucket name and CloudFront information to `serverless/domain` component.

For the consumer,  there will be few CloudFront properties 

```yaml
myWebsite:
  component: "@serverless/website"
  inputs:
    cloudFront: # (Optional)
        waitForCreateDistribution: true  # (Optional) wait for create CloudFront distribution to complete
        waitForUpdateDistribution: false # (Optional) wait for update CloudFront distribution to complete
        customOrigin: true # (Optional)  wait for custom origin to avoid s3 bucket redirect during cloudfront creation
```
`CustomOrigin` is required to avoid CloudFront url redirection to s3 website redirection for initial 30-40 minutes.