### PR TITLE
Allowing flexible index and error names

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ inputs:
   src: ./src                     # (optional) path to the source folder. default is a hello world html file.
   domain: serverless.com         # (optional) domain name. this could also be a subdomain.
   region: us-east-2              # (optional) aws region to deploy to. default is us-east-1.
+  indexDocument: index.html      # (optional) index document for your website. default is index.html.
+  errorDocument: index.html      # (optional) error document for your website. default is index.html.
 ```
 
 Once you've chosen your configuration, run `serverless deploy` again (or simply just `serverless`) to deploy your changes.

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -73,7 +73,7 @@ class Website extends Component {
       log(`Configuring bucket for hosting`)
       log(`Uploading Website files`)
       await Promise.all([
-        configureBucketForHosting(clients, config.bucketName),
+        configureBucketForHosting(clients, config.bucketName, config.indexDocument, config.errorDocument),
         uploadDir(clients, config.bucketName, config.src, this)
       ])
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,8 @@ const shouldConfigureNakedDomain = (domain) => {
 
 const getConfig = (inputs, state) => {
   const config = {}
+  config.indexDocument = inputs.indexDocument || 'index.html'
+  config.errorDocument = inputs.errorDocument || 'index.html'
   config.bucketName = inputs.bucketName || state.bucketName || `website-${generateId()}`
   config.region = inputs.region || state.region || 'us-east-1'
   config.bucketUrl = `http://${config.bucketName}.s3-website-${config.region}.amazonaws.com`
@@ -221,7 +223,7 @@ const uploadDir = async (clients, bucketName, zipPath, instance) => {
   await Promise.all(uploadItems)
 }
 
-const configureBucketForHosting = async (clients, bucketName) => {
+const configureBucketForHosting = async (clients, bucketName, indexDocument, errorDocument) => {
   const s3BucketPolicy = {
     Version: '2012-10-17',
     Statement: [
@@ -240,10 +242,10 @@ const configureBucketForHosting = async (clients, bucketName) => {
     Bucket: bucketName,
     WebsiteConfiguration: {
       ErrorDocument: {
-        Key: 'index.html'
+        Key: errorDocument
       },
       IndexDocument: {
-        Suffix: 'index.html'
+        Suffix: indexDocument
       }
     }
   }


### PR DESCRIPTION
This pull request enables users to be able to override default names for index and error files for a bucket, if they so desire.

Closes #28 