### PR TITLE
Output correct bucketUrl

### DIFF
--- a/src/serverless.js
+++ b/src/serverless.js
@@ -124,7 +124,7 @@ class Website extends Component {
 
     const outputs = {
       bucket: this.state.bucketName,
-      bucketUrl: `http://${this.state.bucketName}.s3-website-us-east-1.amazonaws.com`,
+      bucketUrl: `http://${this.state.bucketName}.s3-website.${this.state.region}.amazonaws.com`,
       url: `https://${this.state.distributionUrl}`
     }
 


### PR DESCRIPTION
If region was other than us-east-1 before, the output gave the wrong bucketUrl. Now using the region to create the bucketUrl.