### PR TITLE
Origin DomainName of CloudFront dist must include region

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -480,7 +480,7 @@ const createCloudFrontDistribution = async (clients, config) => {
         Items: [
           {
             Id: config.bucketName,
-            DomainName: `${config.bucketName}.s3.amazonaws.com`,
+            DomainName: `${config.bucketName}.s3.${config.region}.amazonaws.com`,
             CustomHeaders: {
               Quantity: 0,
               Items: []


### PR DESCRIPTION
Cloudfront needs the region as part of the origin URL to work correctly (at least for regions other than us-east-1).