### PR TITLE
Cloudfront Alternate Domain Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ stage: dev                       # (optional) serverless dashboard stage. defaul
 inputs:
   src: ./src                     # (optional) path to the source folder. default is a hello world html file.
   domain: serverless.com         # (optional) domain name. this could also be a subdomain.
+  alternateDomainNames: altDomainA.serverless.com,altDomainB.serverless.com         # (optional) alternate cloudfront domain names, separated by a comma.
   region: us-east-2              # (optional) aws region to deploy to. default is us-east-1.
   bucketName: my-bucket          # (optional) aws bucket name. default is an auto generated name.
   indexDocument: index.html      # (optional) index document for your website. default is index.html.

--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,5 +1,5 @@
 name: website-alternate-domains
-version: 1.0.1
+version: 1.0.3
 org: roodrallec
 description: Variation of Serverless Website Component for Alternate Cloudfront Domain Names
 keywords: aws, serverless, website

--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,9 +1,9 @@
-name: website
-version: 1.1.2
-org: serverlessinc
-description: Deploys Serverless Websites
+name: website-alternate-domains
+version: 1.0.1
+org: roodrallec
+description: Variation of Serverless Website Component for Alternate Cloudfront Domain Names
 keywords: aws, serverless, website
-repo: https://github.com/serverless-components/website
+repo: https://github.com/Syndi-Health/website
 license: MIT
 src: ./src
 types:

--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,9 +1,9 @@
-name: website-alternate-domains
-version: 1.0.3
-org: roodrallec
-description: Variation of Serverless Website Component for Alternate Cloudfront Domain Names
+name: website
+version: 1.1.2
+org: serverlessinc
+description: Deploys Serverless Websites
 keywords: aws, serverless, website
-repo: https://github.com/Syndi-Health/website
+repo: https://github.com/serverless-components/website
 license: MIT
 src: ./src
 types:

--- a/src/serverless.js
+++ b/src/serverless.js
@@ -150,6 +150,10 @@ class Website extends Component {
       outputs.domain = `https://${config.domain}`
     }
 
+    if (config.alternateDomainNames) {
+      outputs.alternateDomainNames = config.alternateDomainNames
+    }
+
     return outputs
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -99,6 +99,9 @@ const getConfig = (inputs, state) => {
   config.domainHostedZoneId = config.domain ? state.domainHostedZoneId : null
   config.certificateArn = state.certificateArn
 
+  // for alternate cloudfront CNAME domains
+  config.alternateDomainNames = inputs.alternateDomainNames
+
   // if user input example.com, make sure we also setup www.example.com
   if (config.domain && config.domain === config.nakedDomain) {
     config.domain = `www.${config.domain}`
@@ -597,6 +600,13 @@ const createCloudFrontDistribution = async (clients, config) => {
       log(`Adding domain "${config.nakedDomain}" to CloudFront distribution`)
       distributionConfig.Aliases.Quantity = 2
       distributionConfig.Aliases.Items.push(config.nakedDomain)
+    }
+
+    if (Array.isArray(config.alternateDomainNames)) {
+      config.alternateDomainNames.forEach((domain) => {
+        distributionConfig.Aliases.Quantity += 1
+        distributionConfig.Aliases.Items.push(domain)
+      })
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -101,6 +101,8 @@ const getConfig = (inputs, state) => {
 
   // for alternate cloudfront CNAME domains
   config.alternateDomainNames = inputs.alternateDomainNames
+    ? inputs.alternateDomainNames.split(',')
+    : null
 
   // if user input example.com, make sure we also setup www.example.com
   if (config.domain && config.domain === config.nakedDomain) {
@@ -676,6 +678,13 @@ const updateCloudFrontDistribution = async (clients, config) => {
         log(`Adding domain "${config.nakedDomain}" to CloudFront distribution`)
         params.DistributionConfig.Aliases.Quantity = 2
         params.DistributionConfig.Aliases.Items.push(config.nakedDomain)
+      }
+
+      if (Array.isArray(config.alternateDomainNames)) {
+        config.alternateDomainNames.forEach((domain) => {
+          params.DistributionConfig.Aliases.Quantity += 1
+          params.DistributionConfig.Aliases.Items.push(domain)
+        })
       }
     }
     // 6. then finally update!


### PR DESCRIPTION
### Description
This PR is a suggestion for allowing alternate cloudfront domain names on component deploy. Previously, manually set alternate domain names are wiped from the cloudfront distribution on deploy.

### Use Case
If you would like to add alternate domain names to the cloudfront distribution:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#CreatingCNAME

### Instructions
To use this configuration, add an ```alternateDomainNames``` property to the serverless.yml file, with a comma separated list of alternate domain names. This component will then ensure that they are added to the cloudfront distribution on deploy and update. You will have to configure the alternate domain names on AWS Route 53 to point to the cloudfront distribution manually. 

